### PR TITLE
Added SSL functionality

### DIFF
--- a/routeros_api.class.php
+++ b/routeros_api.class.php
@@ -19,7 +19,8 @@ class RouterosAPI
 {
     var $debug     = false; //  Show debug information
     var $connected = false; //  Connection state
-    var $port      = 8728;  //  Port to connect to
+    var $port      = 8728;  //  Port to connect to (default 8729 for ssl)
+    var $ssl       = false; //  Connect using SSL (must enable api-ssl in IP/Services)
     var $timeout   = 3;     //  Connection attempt timeout and data read timeout
     var $attempts  = 5;     //  Connection attempt count
     var $delay     = 3;     //  Delay between connection attempts in seconds
@@ -95,8 +96,9 @@ class RouterosAPI
     {
         for ($ATTEMPT = 1; $ATTEMPT <= $this->attempts; $ATTEMPT++) {
             $this->connected = false;
-            $this->debug('Connection attempt #' . $ATTEMPT . ' to ' . $ip . ':' . $this->port . '...');
-            $this->socket = @fsockopen($ip, $this->port, $this->error_no, $this->error_str, $this->timeout);
+            $PROTOCOL = ($this->ssl ? 'ssl://' : '' );
+            $this->debug('Connection attempt #' . $ATTEMPT . ' to ' . $PROTOCOL . $ip . ':' . $this->port . '...');
+            $this->socket = @fsockopen($PROTOCOL . $ip, $this->port, $this->error_no, $this->error_str, $this->timeout);
             if ($this->socket) {
                 socket_set_timeout($this->socket, $this->timeout);
                 $this->write('/login');


### PR DESCRIPTION
Added class boolean variable $ssl.
Changed connect method to use SSL for connections if $ssl is set to true.
api-ssl must be enabled on the routeros config under /IP/Services and uses port 8729 by default.

This would enable SSL to be used for api connections.