### PR TITLE
API-SSL without certificate 

### DIFF
--- a/routeros_api.class.php
+++ b/routeros_api.class.php
@@ -97,8 +97,9 @@ class RouterosAPI
         for ($ATTEMPT = 1; $ATTEMPT <= $this->attempts; $ATTEMPT++) {
             $this->connected = false;
             $PROTOCOL = ($this->ssl ? 'ssl://' : '' );
+            $context = stream_context_create(['ssl' => ['ciphers' => 'ADH', 'verify_peer' => false, 'verify_peer_name' => false]]);
             $this->debug('Connection attempt #' . $ATTEMPT . ' to ' . $PROTOCOL . $ip . ':' . $this->port . '...');
-            $this->socket = @fsockopen($PROTOCOL . $ip, $this->port, $this->error_no, $this->error_str, $this->timeout);
+            $this->socket = @stream_socket_client($PROTOCOL . $ip.':'. $this->port, $this->error_no, $this->error_str, $this->timeout, STREAM_CLIENT_CONNECT,$context);
             if ($this->socket) {
                 socket_set_timeout($this->socket, $this->timeout);
                 $this->write('/login');

--- a/routeros_api.class.php
+++ b/routeros_api.class.php
@@ -97,7 +97,7 @@ class RouterosAPI
         for ($ATTEMPT = 1; $ATTEMPT <= $this->attempts; $ATTEMPT++) {
             $this->connected = false;
             $PROTOCOL = ($this->ssl ? 'ssl://' : '' );
-            $context = stream_context_create(['ssl' => ['ciphers' => 'ADH:ALL', 'verify_peer' => false, 'verify_peer_name' => false]]);
+            $context = stream_context_create(array('ssl' => array('ciphers' => 'ADH:ALL', 'verify_peer' => false, 'verify_peer_name' => false)));
             $this->debug('Connection attempt #' . $ATTEMPT . ' to ' . $PROTOCOL . $ip . ':' . $this->port . '...');
             $this->socket = @stream_socket_client($PROTOCOL . $ip.':'. $this->port, $this->error_no, $this->error_str, $this->timeout, STREAM_CLIENT_CONNECT,$context);
             if ($this->socket) {

--- a/routeros_api.class.php
+++ b/routeros_api.class.php
@@ -97,7 +97,7 @@ class RouterosAPI
         for ($ATTEMPT = 1; $ATTEMPT <= $this->attempts; $ATTEMPT++) {
             $this->connected = false;
             $PROTOCOL = ($this->ssl ? 'ssl://' : '' );
-            $context = stream_context_create(['ssl' => ['ciphers' => 'ADH', 'verify_peer' => false, 'verify_peer_name' => false]]);
+            $context = stream_context_create(['ssl' => ['ciphers' => 'ADH:ALL', 'verify_peer' => false, 'verify_peer_name' => false]]);
             $this->debug('Connection attempt #' . $ATTEMPT . ' to ' . $PROTOCOL . $ip . ':' . $this->port . '...');
             $this->socket = @stream_socket_client($PROTOCOL . $ip.':'. $this->port, $this->error_no, $this->error_str, $this->timeout, STREAM_CLIENT_CONNECT,$context);
             if ($this->socket) {


### PR DESCRIPTION
In the case no certificate is used in '/ip service' settings then anonymous Diffie-Hellman cipher have to be used to establish connection.
Source: http://wiki.mikrotik.com/wiki/Manual:API-SSL
---
Version:5.6.0
Description: Added peer_fingerprint and verify_peer_name. verify_peer default changed to TRUE.
Source: http://php.net/manual/en/context.ssl.php
---
The function stream_socket_client() is similar but provides a richer set of options, including non-blocking connection and the ability to provide a stream context.
Source: http://php.net/manual/en/function.fsockopen.php
---
'ciphers' => 'ADH:ALL'
Source: https://wiki.openssl.org/index.php/Manual:Ciphers(1)
---