### PR TITLE
Don't strip newlines from commands

### DIFF
--- a/examples/example7.php
+++ b/examples/example7.php
@@ -1,0 +1,23 @@
+<?php
+
+/* Example for adding a multiline script */
+
+require('../routeros_api.class.php');
+
+$API = new RouterosAPI();
+
+$API->debug = true;
+
+if ($API->connect('111.111.111.111', 'LOGIN', 'PASSWORD')) {
+
+   $API->comm("/system/script/add", array(
+      "name"     => "myscript",
+      "source" => ":put line1;
+:put line2;",
+   ));
+
+   $API->disconnect();
+
+}
+
+?>

--- a/routeros_api.class.php
+++ b/routeros_api.class.php
@@ -368,12 +368,9 @@ class RouterosAPI
     public function write($command, $param2 = true)
     {
         if ($command) {
-            $data = explode("\n", $command);
-            foreach ($data as $com) {
-                $com = trim($com);
-                fwrite($this->socket, $this->encodeLength(strlen($com)) . $com);
-                $this->debug('<<< [' . strlen($com) . '] ' . $com);
-            }
+            $com = trim($command);
+            fwrite($this->socket, $this->encodeLength(strlen($com)) . $com);
+            $this->debug('<<< [' . strlen($com) . '] ' . $com);
 
             if (gettype($param2) == 'integer') {
                 fwrite($this->socket, $this->encodeLength(strlen('.tag=' . $param2)) . '.tag=' . $param2 . chr(0));


### PR DESCRIPTION
If a command parameter has multiple lines (eg source for scripts) then only the first line is stored on the Mikrotik. The API sends everything but strips newlines and sends each line separately, the MT doesn't seem to understand this and quietly ignores subsequent lines.

Removing the explode on line 371 (in function write) fixes this problem - not sure what the intended purpose of this is.

The C API implementation does not seem to do this split-on-newline and works as expected.

According to the MT forum, sending multilines with real newlines is what should happen - https://forum.mikrotik.com/viewtopic.php?t=138265&sid=a2763d40024514774a0a87df92e4f73e

See example7 to show this