### PR TITLE
Add option for ssl with no certificate on router

### DIFF
--- a/routeros_api.class.php
+++ b/routeros_api.class.php
@@ -21,6 +21,7 @@ class RouterosAPI
     var $connected = false; //  Connection state
     var $port      = 8728;  //  Port to connect to (default 8729 for ssl)
     var $ssl       = false; //  Connect using SSL (must enable api-ssl in IP/Services)
+    var $certless  = false; //  Set SSL SECLEVEL=0 to allow SSL with no certificates
     var $timeout   = 3;     //  Connection attempt timeout and data read timeout
     var $attempts  = 5;     //  Connection attempt count
     var $delay     = 3;     //  Delay between connection attempts in seconds
@@ -97,7 +98,8 @@ class RouterosAPI
         for ($ATTEMPT = 1; $ATTEMPT <= $this->attempts; $ATTEMPT++) {
             $this->connected = false;
             $PROTOCOL = ($this->ssl ? 'ssl://' : '' );
-            $context = stream_context_create(array('ssl' => array('ciphers' => 'ADH:ALL', 'verify_peer' => false, 'verify_peer_name' => false)));
+            $CERTLESS = ($this->certless ? ':@SECLEVEL=0' : '' );
+            $context = stream_context_create(array('ssl' => array('ciphers' => 'ADH:ALL' . $CERTLESS, 'verify_peer' => false, 'verify_peer_name' => false)));
             $this->debug('Connection attempt #' . $ATTEMPT . ' to ' . $PROTOCOL . $ip . ':' . $this->port . '...');
             $this->socket = @stream_socket_client($PROTOCOL . $ip.':'. $this->port, $this->error_no, $this->error_str, $this->timeout, STREAM_CLIENT_CONNECT,$context);
             if ($this->socket) {


### PR DESCRIPTION
Routeros allows SSL API connections without a certificate on the
router, using an anonymous Diffie-Hellman cipher.
See:  https://wiki.mikrotik.com/wiki/Manual:API-SSL

For this to work the SSL SECLEVEL needs to be set to 0 (vs the
default of 1).

This patch adds a new boolean setting "$certless" (default false) to
allow lowering SECLEVEL to 0 which allows certless SSL API connections
to work.

This fixes https://github.com/BenMenking/routeros-api/issues/54