### PR TITLE
Added namespace to the class

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,23 @@
+# installing with composer from this particular fork
+### 1. Add the following below your name/description:
+```angular2html
+"repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/mario7dujmovic/routeros-api-1.git"
+        }
+    ],
+```
+### 2. Require it in your `require` segment, e.g.:
+```angular2html
+    "require": {
+        (...)
+        "ben-menking/routeros-api": "dev-stable",
+        (...)
+    }
+```
+### 3. run `composer install`
+
 # routeros-api
 Client API for RouterOS/Mikrotik
 

--- a/routeros_api.class.php
+++ b/routeros_api.class.php
@@ -343,7 +343,7 @@ class RouterosAPI
                 $this->debug('>>> [' . $LENGTH . ', ' . $STATUS['unread_bytes'] . ']' . $_);
             }
 
-            if ((!$this->connected && !$STATUS['unread_bytes']) || ($this->connected && !$STATUS['unread_bytes'] && $receiveddone)) {
+            if ((!$this->connected && !$STATUS['unread_bytes']) || ($this->connected && !$STATUS['unread_bytes'] && $receiveddone) || $STATUS['timed_out']) {
                 break;
             }
         }

--- a/routeros_api.class.php
+++ b/routeros_api.class.php
@@ -15,6 +15,8 @@
  *
  ******************************/
 
+namespace RouterosAPI;
+
 class RouterosAPI
 {
     var $debug     = false; //  Show debug information


### PR DESCRIPTION
- this allows for easier usage of the class by utilizing the `use` statement instead of `require` (handy if routeros-api was added through composer)
- also enables IDEs that automatically import the classes into files (such as PHPStorm) to do so