### PR TITLE
fix: socket timeout check

### DIFF
--- a/routeros_api.class.php
+++ b/routeros_api.class.php
@@ -341,7 +341,7 @@ class RouterosAPI
                 $this->debug('>>> [' . $LENGTH . ', ' . $STATUS['unread_bytes'] . ']' . $_);
             }
 
-            if ((!$this->connected && !$STATUS['unread_bytes']) || ($this->connected && !$STATUS['unread_bytes'] && $receiveddone)) {
+            if ((!$this->connected && !$STATUS['unread_bytes']) || ($this->connected && !$STATUS['unread_bytes'] && $receiveddone) || $STATUS['timed_out']) {
                 break;
             }
         }


### PR DESCRIPTION
Sometimes you may get infinity loop, when MikroTik has lost a connection to the network right after sent API command. This fix check the status of the socket, and prevent infinity loop.

You may reproduce the problem: download and then import the [script](https://github.com/IgorAlov/rb-setfw.rsc/blob/main/rb-setfw.rsc) after exec import command you will get infinity loop, cuz the RB rebooted after firmware upgrade. Here I attached an example 

[test_ros_api_class.php.gz](https://github.com/BenMenking/routeros-api/files/9275988/test_ros_api_class.php.gz)

or you can also get sample script on the git [here](https://github.com/IgorAlov/rb-setfw.rsc/blob/main/example_import_script.php).

