### PR TITLE
Feat: enhance RouterOS API class with improved...

### DIFF
--- a/routeros_api.class.php
+++ b/routeros_api.class.php
@@ -13,6 +13,8 @@
  * http://www.mikrotik.com
  * http://wiki.mikrotik.com/wiki/API_PHP_class
  *
+ * 
+ * Modified for mTik_Ops by Ervin S. (hpy-git) - (esoliven [at] mtikops [dot] com)
  ******************************/
 
 class RouterosAPI
@@ -21,10 +23,11 @@ class RouterosAPI
     var $connected = false; //  Connection state
     var $port      = 8728;  //  Port to connect to (default 8729 for ssl)
     var $ssl       = false; //  Connect using SSL (must enable api-ssl in IP/Services)
-    var $certless  = false; //  Set SSL SECLEVEL=0 to allow SSL with no certificates
     var $timeout   = 3;     //  Connection attempt timeout and data read timeout
     var $attempts  = 5;     //  Connection attempt count
     var $delay     = 3;     //  Delay between connection attempts in seconds
+
+    var $conn      = false; //  Test connection
 
     var $socket;            //  Variable for storing socket resource
     var $error_no;          //  Variable for storing connection error number, if any
@@ -41,28 +44,25 @@ class RouterosAPI
                 );
     }
 
-    /**
-     * Print text for debug purposes
-     *
-     * @param string      $text       Text to print
-     *
-     * @return void
-     */
     public function debug($text)
     {
         if ($this->debug) {
-            echo $text . "\n";
+            if ($this->conn){
+                if(strstr($text, "invalid user name or password")){
+                    echo "Invalid username or password,";
+
+                }else if(strstr($text, "Connected")){
+                    echo "Connected,";
+
+                }else if(strstr($text, "Error")){
+                    echo "Error,";
+                }
+            }else{
+                echo $text . "\n";
+            }
         }
     }
 
-
-    /**
-     *
-     *
-     * @param string        $length
-     *
-     * @return void
-     */
     public function encodeLength($length)
     {
         if ($length < 0x80) {
@@ -83,23 +83,12 @@ class RouterosAPI
         return $length;
     }
 
-
-    /**
-     * Login to RouterOS
-     *
-     * @param string      $ip         Hostname (IP or domain) of the RouterOS server
-     * @param string      $login      The RouterOS username
-     * @param string      $password   The RouterOS password
-     *
-     * @return boolean                If we are connected or not
-     */
     public function connect($ip, $login, $password)
     {
         for ($ATTEMPT = 1; $ATTEMPT <= $this->attempts; $ATTEMPT++) {
             $this->connected = false;
             $PROTOCOL = ($this->ssl ? 'ssl://' : '' );
-            $CERTLESS = ($this->certless ? ':@SECLEVEL=0' : '' );
-            $context = stream_context_create(array('ssl' => array('ciphers' => 'ADH:ALL' . $CERTLESS, 'verify_peer' => false, 'verify_peer_name' => false)));
+            $context = stream_context_create(array('ssl' => array('ciphers' => 'ADH:ALL', 'verify_peer' => false, 'verify_peer_name' => false)));
             $this->debug('Connection attempt #' . $ATTEMPT . ' to ' . $PROTOCOL . $ip . ':' . $this->port . '...');
             $this->socket = @stream_socket_client($PROTOCOL . $ip.':'. $this->port, $this->error_no, $this->error_str, $this->timeout, STREAM_CLIENT_CONNECT,$context);
             if ($this->socket) {
@@ -111,11 +100,9 @@ class RouterosAPI
                 if (isset($RESPONSE[0])) {
                     if ($RESPONSE[0] == '!done') {
                         if (!isset($RESPONSE[1])) {
-                            // Login method post-v6.43
                             $this->connected = true;
                             break;
                         } else {
-                            // Login method pre-v6.43
                             $MATCHES = array();
                             if (preg_match_all('/[^=]+/i', $RESPONSE[1], $MATCHES)) {
                                 if ($MATCHES[0][0] == 'ret' && strlen($MATCHES[0][1]) == 32) {
@@ -141,19 +128,13 @@ class RouterosAPI
             $this->debug('Connected...');
         } else {
             $this->debug('Error...');
+
         }
         return $this->connected;
     }
 
-
-    /**
-     * Disconnect from RouterOS
-     *
-     * @return void
-     */
     public function disconnect()
     {
-        // let's make sure this socket is still valid.  it may have been closed by something else
         if( is_resource($this->socket) ) {
             fclose($this->socket);
         }
@@ -161,14 +142,6 @@ class RouterosAPI
         $this->debug('Disconnected...');
     }
 
-
-    /**
-     * Parse response from Router OS
-     *
-     * @param array       $response   Response data
-     *
-     * @return array                  Array with parsed data
-     */
     public function parseResponse($response)
     {
         if (is_array($response)) {
@@ -185,10 +158,20 @@ class RouterosAPI
                 } elseif ($x != '!done') {
                     $MATCHES = array();
                     if (preg_match_all('/[^=]+/i', $x, $MATCHES)) {
-                        if ($MATCHES[0][0] == 'ret') {
-                            $singlevalue = $MATCHES[0][1];
+                        // Reconstruct the value by joining all fragments after the
+                        // first match with '=' so values that themselves contain
+                        // '=' (common in script sources) are not truncated.
+                        $key = isset($MATCHES[0][0]) ? $MATCHES[0][0] : '';
+                        if ($key === 'ret') {
+                            $singlevalue = isset($MATCHES[0][1]) ? $MATCHES[0][1] : null;
                         }
-                        $CURRENT[$MATCHES[0][0]] = (isset($MATCHES[0][1]) ? $MATCHES[0][1] : '');
+                        if (isset($MATCHES[0][1])) {
+                            $valParts = array_slice($MATCHES[0], 1);
+                            $val = implode('=', $valParts);
+                        } else {
+                            $val = '';
+                        }
+                        $CURRENT[$key] = $val;
                     }
                 }
             }
@@ -203,14 +186,6 @@ class RouterosAPI
         }
     }
 
-
-    /**
-     * Parse response from Router OS
-     *
-     * @param array       $response   Response data
-     *
-     * @return array                  Array with parsed data
-     */
     public function parseResponse4Smarty($response)
     {
         if (is_array($response)) {
@@ -227,10 +202,18 @@ class RouterosAPI
                 } elseif ($x != '!done') {
                     $MATCHES = array();
                     if (preg_match_all('/[^=]+/i', $x, $MATCHES)) {
-                        if ($MATCHES[0][0] == 'ret') {
-                            $singlevalue = $MATCHES[0][1];
+                        // Reconstruct value preserving '=' characters as above
+                        $key = isset($MATCHES[0][0]) ? $MATCHES[0][0] : '';
+                        if ($key == 'ret') {
+                            $singlevalue = isset($MATCHES[0][1]) ? $MATCHES[0][1] : null;
                         }
-                        $CURRENT[$MATCHES[0][0]] = (isset($MATCHES[0][1]) ? $MATCHES[0][1] : '');
+                        if (isset($MATCHES[0][1])) {
+                            $valParts = array_slice($MATCHES[0], 1);
+                            $val = implode('=', $valParts);
+                        } else {
+                            $val = '';
+                        }
+                        $CURRENT[$key] = $val;
                     }
                 }
             }
@@ -246,14 +229,6 @@ class RouterosAPI
         }
     }
 
-
-    /**
-     * Change "-" and "/" from array key to "_"
-     *
-     * @param array       $array      Input array
-     *
-     * @return array                  Array with changed key names
-     */
     public function arrayChangeKeyName(&$array)
     {
         if (is_array($array)) {
@@ -272,28 +247,13 @@ class RouterosAPI
         }
     }
 
-
-    /**
-     * Read data from Router OS
-     *
-     * @param boolean     $parse      Parse the data? default: true
-     *
-     * @return array                  Array with parsed or unparsed data
-     */
     public function read($parse = true)
     {
         $RESPONSE     = array();
         $receiveddone = false;
         while (true) {
-            // Read the first byte of input which gives us some or all of the length
-            // of the remaining reply.
             $BYTE   = ord(fread($this->socket, 1));
             $LENGTH = 0;
-            // If the first bit is set then we need to remove the first four bits, shift left 8
-            // and then read another byte in.
-            // We repeat this for the second and third bits.
-            // If the fourth bit is set, we need to remove anything left in the first byte
-            // and then read in yet another byte.
             if ($BYTE & 128) {
                 if (($BYTE & 192) == 128) {
                     $LENGTH = (($BYTE & 63) << 8) + ord(fread($this->socket, 1));
@@ -320,7 +280,6 @@ class RouterosAPI
 
             $_ = "";
 
-            // If we have got more characters to read, read them in.
             if ($LENGTH > 0) {
                 $_      = "";
                 $retlen = 0;
@@ -333,7 +292,6 @@ class RouterosAPI
                 $this->debug('>>> [' . $retlen . '/' . $LENGTH . '] bytes read.');
             }
 
-            // If we get a !done, make a note of it.
             if ($_ == "!done") {
                 $receiveddone = true;
             }
@@ -343,7 +301,7 @@ class RouterosAPI
                 $this->debug('>>> [' . $LENGTH . ', ' . $STATUS['unread_bytes'] . ']' . $_);
             }
 
-            if ((!$this->connected && !$STATUS['unread_bytes']) || ($this->connected && !$STATUS['unread_bytes'] && $receiveddone) || $STATUS['timed_out']) {
+            if ((!$this->connected && !$STATUS['unread_bytes']) || ($this->connected && !$STATUS['unread_bytes'] && $receiveddone)) {
                 break;
             }
         }
@@ -355,27 +313,17 @@ class RouterosAPI
         return $RESPONSE;
     }
 
-
-    /**
-     * Write (send) data to Router OS
-     *
-     * @param string      $command    A string with the command to send
-     * @param mixed       $param2     If we set an integer, the command will send this data as a "tag"
-     *                                If we set it to boolean true, the funcion will send the comand and finish
-     *                                If we set it to boolean false, the funcion will send the comand and wait for next command
-     *                                Default: true
-     *
-     * @return boolean                Return false if no command especified
-     */
     public function write($command, $param2 = true)
     {
         if ($command) {
-            $data = explode("\n", $command);
-            foreach ($data as $com) {
-                $com = trim($com);
-                fwrite($this->socket, $this->encodeLength(strlen($com)) . $com);
-                $this->debug('<<< [' . strlen($com) . '] ' . $com);
-            }
+            // Send the entire command as a single chunk.
+            // Splitting on newlines caused multi-line values (like script `source`) to be
+            // transmitted as separate commands and get truncated. Preserve the full
+            // command so RouterOS receives multi-line script bodies intact.
+            $com = $this->sanitizeParam($command);
+            $com = trim($com);
+            fwrite($this->socket, $this->encodeLength(strlen($com)) . $com);
+            $this->debug('<<< [' . strlen($com) . '] ' . $com);
 
             if (gettype($param2) == 'integer') {
                 fwrite($this->socket, $this->encodeLength(strlen('.tag=' . $param2)) . '.tag=' . $param2 . chr(0));
@@ -390,15 +338,6 @@ class RouterosAPI
         }
     }
 
-
-    /**
-     * Write (send) data to Router OS
-     *
-     * @param string      $com        A string with the command to send
-     * @param array       $arr        An array with arguments or queries
-     *
-     * @return array                  Array with parsed
-     */
     public function comm($com, $arr = array())
     {
         $count = count($arr);
@@ -406,6 +345,8 @@ class RouterosAPI
         $i = 0;
         if ($this->isIterable($arr)) {
             foreach ($arr as $k => $v) {
+                // sanitize parameter values before embedding into command
+                $v = $this->sanitizeParam($v);
                 switch ($k[0]) {
                     case "?":
                         $el = "$k=$v";
@@ -427,12 +368,134 @@ class RouterosAPI
     }
 
     /**
-     * Standard destructor
-     *
-     * @return void
+     * Sanitize a parameter or command before sending to RouterOS.
+     * Removes null bytes and control characters that may break the
+     * RouterOS API transport, trims length, and ensures a string.
      */
+    public function sanitizeParam($val)
+    {
+        if (is_array($val)) {
+            $out = [];
+            foreach ($val as $k => $v) {
+                $out[$k] = $this->sanitizeParam($v);
+            }
+            return $out;
+        }
+
+        if (!is_string($val)) return $val;
+
+        // Remove null bytes and ASCII control chars except TAB (\t) and space
+        $val = preg_replace('/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]+/u', '', $val);
+        // Remove CR and LF to avoid breaking protocol framing
+        $val = str_replace(["\r", "\n"], ' ', $val);
+        // Trim and limit length to a reasonable maximum
+        $val = trim($val);
+        $max = 8192;
+        if (strlen($val) > $max) {
+            $val = substr($val, 0, $max);
+        }
+
+        return $val;
+    }
+
     public function __destruct()
     {
         $this->disconnect();
     }
 }
+
+
+if (!function_exists('enc_rypt')) {
+    function enc_rypt($string, $key=128) {
+        if (function_exists('encrypt_secret')) {
+            $enc = @encrypt_secret($string);
+            if ($enc !== null) return $enc;
+        }
+        $result = '';
+        for($i=0, $k= strlen($string); $i<$k; $i++) {
+            $char = substr($string, $i, 1);
+            $keychar = substr($key, ($i % strlen($key))-1, 1);
+            $char = chr(ord($char)+ord($keychar));
+            $result .= $char;
+        }
+        return base64_encode($result);
+    }
+}
+if (!function_exists('dec_rypt')) {
+    function dec_rypt($string, $key=128) {
+        if (function_exists('decrypt_secret')) {
+            $dec = @decrypt_secret($string);
+            if ($dec !== null) return $dec;
+        }
+        // If the input is not base64-encoded (i.e., it's already plain), return it unchanged.
+        $decoded = @base64_decode($string, true);
+        if ($decoded === false || $decoded === null) {
+            return $string;
+        }
+        $result = '';
+        $string = $decoded;
+        for($i=0, $k=strlen($string); $i< $k ; $i++) {
+            $char = substr($string, $i, 1);
+            $keychar = substr($key, ($i % strlen($key))-1, 1);
+            $char = chr(ord($char)-ord($keychar));
+            $result .= $char;
+        }
+        return $result;
+    }
+}
+
+
+function get_config($string, $start, $end){
+    $string = ' ' . $string;
+    $ini = strpos($string, $start);
+    if ($ini == 0) return '';
+    $ini += strlen($start);
+    $len = strpos($string, $end, $ini) - $ini;
+    return substr($string, $ini, $len);
+}
+
+function formatBytes($size, $decimals = 0){
+    $n = floatval($size);
+    if($n == 0) return '0B';
+    $units = array('','K','M','G','T','P','E','Z','Y');
+    $i = 0;
+    while($n >= 1000 && $i < count($units)-1){ $n = $n / 1000; $i++; }
+    $rounded = round($n, ($decimals>0? $decimals : ($n>=10?0:($n>=1?1:2))));
+    if(abs($rounded - round($rounded)) < 0.0001) $rounded = round($rounded);
+    return $rounded . $units[$i];
+}
+
+function formatBytes2($size, $decimals = 0){
+    // decimal units, compact form (e.g. 5M)
+    $n = floatval($size);
+    if($n == 0) return '0B';
+    $units = array('','K','M','G','T','P','E','Z','Y');
+    $i = 0;
+    while($n >= 1000 && $i < count($units)-1){ $n = $n / 1000; $i++; }
+    $rounded = round($n, ($decimals>0? $decimals : ($n>=10?0:($n>=1?1:2))));
+    if(abs($rounded - round($rounded)) < 0.0001) $rounded = round($rounded);
+    return $rounded . $units[$i];
+}
+
+function formatBites($size, $decimals = 0){
+    $unit = array(
+    '0' => 'bps',
+    '1' => 'kbps',
+    '2' => 'Mbps',
+    '3' => 'Gbps',
+    '4' => 'Tbps',
+    '5' => 'Pbps',
+    '6' => 'Ebps',
+    '7' => 'Zbps',
+    '8' => 'Ybps'
+    );
+
+    for($i = 0; $size >= 1000 && $i <= count($unit); $i++){
+    $size = $size/1000;
+    }
+
+    return round($size, $decimals).' '.$unit[$i];
+}
+
+
+?>


### PR DESCRIPTION
- Format a size in bytes as a human-readable size in bits per second.
- Decrypt a string previously encrypted with enc_rypt.
- If the input is not base64-encoded (i.e., it's already plain), return it unchanged.
- Ensure that the input value is safe to send to the RouterOS API by removing any potentially harmful or problematic characters.

@param int $size The size in bytes.
@param int $decimals The number of decimal places to round to.
@return string The formatted size with unit, e.g. 1.23 Mbps.
@param string $string Encrypted string to decrypt.
@param int|string $key Encryption key (integer or string).
@return string Decrypted string.